### PR TITLE
DEV: Set post model

### DIFF
--- a/javascripts/discourse/widgets/category-sidebar.js
+++ b/javascripts/discourse/widgets/category-sidebar.js
@@ -105,6 +105,7 @@ createWidget("category-sidebar", {
   getPost(id) {
     if (!postCache[id]) {
       ajax(`/t/${id}.json`).then((response) => {
+        this.model = response.post_stream.posts[0];
         postCache[id] = new PostCooked(
           {
             cooked: response.post_stream.posts[0].cooked,


### PR DESCRIPTION
This PR explicitly adds the post model so that errors aren't caused when the post model is accessed by other components (such as `discourse-checklist`). No additional tests applicable.