### PR TITLE
DEV: Add topic data to post model

### DIFF
--- a/javascripts/discourse/widgets/category-sidebar.js
+++ b/javascripts/discourse/widgets/category-sidebar.js
@@ -106,6 +106,8 @@ createWidget("category-sidebar", {
     if (!postCache[id]) {
       ajax(`/t/${id}.json`).then((response) => {
         this.model = response.post_stream.posts[0];
+        this.model.topic = response;
+
         postCache[id] = new PostCooked(
           {
             cooked: response.post_stream.posts[0].cooked,


### PR DESCRIPTION
Model currently lacks topic data from response which causes issues with the `DiscoTOC` component which is trying to access `topic.category_id`. 
This PR adds the topic data in the model to suppress errors. No additional tests necessary.